### PR TITLE
feat: Adiciona endpoint para contagem de atividades por usuário

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@prisma/client": "^6.10.1",
+        "@prisma/client": "^6.8.2",
         "bcrypt": "^5.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -36,7 +36,7 @@
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.6",
         "nodemon": "^3.1.10",
-        "prisma": "^6.10.1",
+        "prisma": "^6.8.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.5"
       },
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
-      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.8.2.tgz",
+      "integrity": "sha512-5II+vbyzv4si6Yunwgkj0qT/iY0zyspttoDrL3R4BYgLdp42/d2C8xdi9vqkrYtKt9H32oFIukvyw3Koz5JoDg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
-      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.8.2.tgz",
+      "integrity": "sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -188,53 +188,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
-      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.8.2.tgz",
+      "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
-      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.8.2.tgz",
+      "integrity": "sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/fetch-engine": "6.10.1",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.8.2",
+        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
+        "@prisma/fetch-engine": "6.8.2",
+        "@prisma/get-platform": "6.8.2"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
-      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
+      "version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e.tgz",
+      "integrity": "sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
-      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.8.2.tgz",
+      "integrity": "sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1",
-        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
-        "@prisma/get-platform": "6.10.1"
+        "@prisma/debug": "6.8.2",
+        "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e",
+        "@prisma/get-platform": "6.8.2"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
-      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.8.2.tgz",
+      "integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.10.1"
+        "@prisma/debug": "6.8.2"
       }
     },
     "node_modules/@scarf/scarf": {
@@ -2279,15 +2279,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
-      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.8.2.tgz",
+      "integrity": "sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.10.1",
-        "@prisma/engines": "6.10.1"
+        "@prisma/config": "6.8.2",
+        "@prisma/engines": "6.8.2"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.6",
     "nodemon": "^3.1.10",
-    "prisma": "^6.10.1",
+    "prisma": "^6.8.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@prisma/client": "^6.10.1",
+    "@prisma/client": "^6.8.2",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",

--- a/src/controllers/usersController.ts
+++ b/src/controllers/usersController.ts
@@ -91,5 +91,11 @@ export default {
         const updatedUser = await usersService.updateProfile(userId, updateData);
 
         return response.status(200).json(updatedUser);
-    }
+    },
+      async getUserActivitiesCount(request: Request, response: Response) {
+        const { id } = request.params;
+        const count = await usersService.countUserActivities(id);
+        
+        return response.status(200).json({ totalActivities: count });
+    },
 }

--- a/src/repositories/usersAtActivitiesRepository.ts
+++ b/src/repositories/usersAtActivitiesRepository.ts
@@ -98,5 +98,16 @@ export default {
                 id
             }
         })
+    },
+    async countByUserId(userId: string): Promise<number> {
+        const count = await client.userAtActivity.count({
+            where: {
+                userId: userId,
+                // Opcional: usar essa linha se quiser contar apenas inscrições
+                // que não sejam em lista de espera.
+                // listaEspera: false 
+            },
+        });
+        return count;
     }
 }

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -306,4 +306,38 @@ routes.get('/getUserRanking/:id', usersController.getUserRanking)
  */
 routes.patch('/updateProfile', authMiddleware, usersController.updateProfile)
 
+
+/**
+ * @swagger
+ * /users/{id}/activities/count:
+ *   get:
+ *     summary: Retorna a quantidade de atividades de um usuário
+ *     description: Retorna a quantidade total de atividades em que um usuário específico está inscrito.
+ *     tags: [Users]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: ID do usuário
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       '200':
+ *         description: Contagem de atividades recuperada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 totalActivities:
+ *                   type: integer
+ *                   example: 5
+ *       '404':
+ *         description: Usuário não encontrado
+ *       '500':
+ *         description: Erro interno do servidor
+ */
+routes.get('/:id/activities/count', usersController.getUserActivitiesCount);
+
 export default routes

--- a/src/services/usersAtActivitiesService.ts
+++ b/src/services/usersAtActivitiesService.ts
@@ -109,4 +109,5 @@ export default {
         }
         return userAtActivity
     },
+  
 }

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -2,6 +2,7 @@ import * as jwt from "jsonwebtoken"
 import * as nodemailer from "nodemailer"
 import _ from "lodash"
 import usersRepository from '../repositories/usersRepository';
+import usersAtActivitiesRepository from '../repositories/usersAtActivitiesRepository';
 import { compareSync, hashSync, hash } from 'bcrypt';
 import { auth } from '../config/auth';
 import { email } from '../config/sendEmail';
@@ -318,5 +319,19 @@ export default {
         const { senha: _, ...userResult } = updatedUser;
 
         return userResult;
+    },
+       async countUserActivities(userId: string): Promise<number> {
+        try {
+            const user = await usersRepository.findById(userId);
+            if (!user) {
+                throw new Error("Usuário não encontrado.");
+            }
+            
+            const totalActivities = await usersAtActivitiesRepository.countByUserId(userId);
+            return totalActivities;
+
+        } catch (error) {
+            throw new Error('Erro ao contar as atividades do usuário');
+        }
     },
 }


### PR DESCRIPTION
Implementa um novo endpoint na API para retornar a quantidade total de atividades em que um usuário específico está inscrito.

Foi-se modificados 4 arquivos:

- `routes/users.ts`: Adicionada a rota `GET /:id/activities/count` , apontando para o novo método no `usersController`.
- `controllers/usersController.ts`: Criado o método `getUserActivitiesCount`.
- `services/usersService.ts`: Implementado o método `countUserActivities`.
- `repositories/usersAtActivitiesRepository.ts`: Adicionado um novo método `countByUserId`.
